### PR TITLE
use short commit because of k8s pod name length limit

### DIFF
--- a/.github/workflows/repository-deployment.yml
+++ b/.github/workflows/repository-deployment.yml
@@ -23,7 +23,7 @@ jobs:
           if [ `git rev-list --max-count=1 HEAD` == `git rev-list --merges --max-count=1 HEAD` ]; then
             IS_MERGE=true
           else
-            COMMIT=`git log --format="%H" -n 1`
+            FULL=`git log --format="%H" -n 1` && COMMIT="${FULL:0:8}"
             TEMPLATE_FILE=${WORK_DIR}/templates/ovirt-hosted-engine-setup-job.yaml.j2
             JOB_FILE=${WORK_DIR}/tmp/ovirt-hosted-engine-setup-job-${COMMIT}.yaml
             echo ::set-output name=COMMIT::${COMMIT}


### PR DESCRIPTION
- k8s Pod name의 길이제한이 63이어서 commit number를 job을 생성할 때 name으로 사용하면 문제가 발생함